### PR TITLE
Fix expected names of default RTS stats

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -38,7 +38,7 @@
 
       <div class="row">
         <div id="plots" class="span11">
-          <div id="current-bytes-used-plot" class="plot-container">
+          <div id="live-bytes-plot" class="plot-container">
             <h3>Current residency</h3>
             <div class="plot"></div>
           </div>
@@ -66,19 +66,19 @@
             <tbody>
               <tr>
                 <td>Maximum residency</td>
-                <td id="max-bytes-used" class="span3 value">0</td>
+                <td id="max-live-bytes" class="span3 value">0</td>
               </tr>
               <tr>
                 <td>Current residency</td>
-                <td id="current-bytes-used" class="value">0</td>
+                <td id="live-bytes" class="value">0</td>
               </tr>
               <tr>
                 <td>Maximum slop</td>
-                <td id="max-bytes-slop" class="value">0</td>
+                <td id="max-slop-bytes" class="value">0</td>
               </tr>
               <tr>
                 <td>Current slop</td>
-                <td id="current-bytes-slop" class="value">0</td>
+                <td id="slop-bytes" class="value">0</td>
               </tr>
               <tr>
                 <td>Productivity (wall clock time)</td>

--- a/assets/monitor.js
+++ b/assets/monitor.js
@@ -369,49 +369,49 @@ $(document).ready(function () {
 
     function initAll() {
         // Metrics
-        var current_bytes_used = function (stats) {
-            return stats.rts.gc.current_bytes_used[0].value.val;
+        var live_bytes = function (stats) {
+            return stats.rts.gc.live_bytes[0].value.val;
         };
-        var max_bytes_used = function (stats) {
-            return stats.rts.gc.max_bytes_used[0].value.val;
+        var max_live_bytes = function (stats) {
+            return stats.rts.max_live_bytes[0].value.val;
         };
-        var max_bytes_slop = function (stats) {
-            return stats.rts.gc.max_bytes_slop[0].value.val;
+        var max_slop_bytes = function (stats) {
+            return stats.rts.max_slop_bytes[0].value.val;
         };
-        var current_bytes_slop = function (stats) {
-            return stats.rts.gc.current_bytes_slop[0].value.val;
+        var slop_bytes = function (stats) {
+            return stats.rts.gc.slop_bytes[0].value.val;
         };
         var productivity_wall_percent = function (stats, time, prev_stats, prev_time) {
             if (prev_stats == undefined)
                 return null;
-            var mutator_ms = stats.rts.gc.mutator_wall_ms[0].value.val -
-                prev_stats.rts.gc.mutator_wall_ms[0].value.val;
-            var gc_ms = stats.rts.gc.gc_wall_ms[0].value.val -
-                prev_stats.rts.gc.gc_wall_ms[0].value.val;
-            return 100 * mutator_ms / (mutator_ms + gc_ms);
+            var mutator_ns = stats.rts.mutator_elapsed_ns[0].value.val -
+                prev_stats.rts.mutator_elapsed_ns[0].value.val;
+            var gc_ns = stats.rts.gc_elapsed_ns[0].value.val -
+                prev_stats.rts.gc_elapsed_ns[0].value.val;
+            return 100 * mutator_ns / (mutator_ns + gc_ns);
         };
         var productivity_cpu_percent = function (stats, time, prev_stats, prev_time) {
             if (prev_stats == undefined)
                 return null;
-            var mutator_ms = stats.rts.gc.mutator_cpu_ms[0].value.val -
-                prev_stats.rts.gc.mutator_cpu_ms[0].value.val;
-            var gc_ms = stats.rts.gc.gc_cpu_ms[0].value.val -
-                prev_stats.rts.gc.gc_cpu_ms[0].value.val;
-            return 100 * mutator_ms / (mutator_ms + gc_ms);
+            var mutator_ns = stats.rts.mutator_cpu_ns[0].value.val -
+                prev_stats.rts.mutator_cpu_ns[0].value.val;
+            var gc_ns = stats.rts.gc_cpu_ns[0].value.val -
+                prev_stats.rts.gc_cpu_ns[0].value.val;
+            return 100 * mutator_ns / (mutator_ns + gc_ns);
         };
         var allocation_rate = function (stats, time, prev_stats, prev_time) {
             if (prev_stats == undefined)
                 return null;
-            return 1000 * (stats.rts.gc.bytes_allocated[0].value.val -
-                           prev_stats.rts.gc.bytes_allocated[0].value.val) /
+            return 1000 * (stats.rts.allocated_bytes[0].value.val -
+                           prev_stats.rts.allocated_bytes[0].value.val) /
                 (time - prev_time);
         };
 
         addMetrics($("#metric-table"));
 
         // Plots
-        addPlot($("#current-bytes-used-plot > div"),
-                [{ label: "residency", fn: current_bytes_used }],
+        addPlot($("#live-bytes-plot > div"),
+                [{ label: "residency", fn: live_bytes }],
                 { yaxis: { tickFormatter: suffixFormatter } });
         addPlot($("#allocation-rate-plot > div"),
                 [{ label: "rate", fn: allocation_rate }],
@@ -422,10 +422,10 @@ $(document).ready(function () {
                 { yaxis: { tickDecimals: 1, tickFormatter: percentFormatter } });
 
         // GC and memory statistics
-        addCounter($("#max-bytes-used"), max_bytes_used, formatSuffix);
-        addCounter($("#current-bytes-used"), current_bytes_used, formatSuffix);
-        addCounter($("#max-bytes-slop"), max_bytes_slop, formatSuffix);
-        addCounter($("#current-bytes-slop"), current_bytes_slop, formatSuffix);
+        addCounter($("#max-live-bytes"), max_live_bytes, formatSuffix);
+        addCounter($("#live-bytes"), live_bytes, formatSuffix);
+        addCounter($("#max-slop-bytes"), max_slop_bytes, formatSuffix);
+        addCounter($("#slop-bytes"), slop_bytes, formatSuffix);
         addCounter($("#productivity-wall"), productivity_wall_percent, formatPercent);
         addCounter($("#productivity-cpu"), productivity_cpu_percent, formatPercent);
         addCounter($("#allocation-rate"), allocation_rate, formatRate);


### PR DESCRIPTION
Our `ekg-core` fork updated the names of some RTS statistics in [this commit](https://github.com/hasura/ekg-core/commit/c8d09e523bf2547d21c98f45e822e055970e9816), but `ekg` was not updated to use the new names. As a result, this `ekg` fork has been non-functional since then.

This PR updates the names of the affected RTS metrics, and thereby restores the functionality of `ekg`.